### PR TITLE
Reduce duplication in league_night show

### DIFF
--- a/app/views/league_nights/show.html.erb
+++ b/app/views/league_nights/show.html.erb
@@ -20,7 +20,7 @@
 		<% end %>
 		<th>Diff</th>
 		<% LeagueGame.where(league_night_id: @league_night).each do |league_game| %>
-		
+
 			<tr>
 				<td><%= league_game.game.title %></td>
 				<% scores = [] %>
@@ -76,135 +76,30 @@ $(".player").mouseout(function() {
 });
 </script>
 
-<div class="graph-container">
-<h3><%= @league_night.league_games[0].game.title %></h3>
-<canvas id="game0" width="800" height="400"></canvas>
-<script>
+<% @league_night.league_games.each_with_index do |league_game, index| %>
+<div class="graph-container <%= "left" unless index == 0 %>">
+  <h3><%= league_game.game.title %></h3>
+  <canvas id="game<%= index %>" width="800" height="400"></canvas>
+  <script>
+  	var data = {
+  	    labels: <%= league_game.scores.includes(:player).collect{|s| s.player.nickname}.to_json.html_safe %>,
+  	    datasets: [
+  	        {
+  	            label: "<%= league_game.game.title %> scores",
+  	            fillColor: "rgba(189,228,168,0.5)",
+  	            strokeColor: "rgba(189,228,168,0.8)",
+  	            highlightFill: "rgba(123,178,168,0.75)",
+  	            highlightStroke: "rgba(123,178,168,1)",
+  	            data: <%= league_game.scores.collect(&:score) %>
+  	        }
+  	    ]
+  	};
 
-	var data = {
-	    labels: <%= @league_night.league_games[0].scores.includes(:player).collect{|s| s.player.nickname}.to_json.html_safe %>,
-	    datasets: [
-	        {
-	            label: "My First dataset",
-	            fillColor: "rgba(189,228,168,0.5)",
-	            strokeColor: "rgba(189,228,168,0.8)",
-	            highlightFill: "rgba(123,178,168,0.75)",
-	            highlightStroke: "rgba(123,178,168,1)",
-	            data: <%= @league_night.league_games[0].scores.collect(&:score) %>
-	        }
-	    ]
-	};
-
-	var ctx = document.getElementById("game0").getContext("2d");
-	new Chart(ctx).Bar(data, {});
-
-</script>
+  	var ctx = document.getElementById("game<%= index %>").getContext("2d");
+  	new Chart(ctx).Bar(data, {});
+  </script>
 </div>
-
-<div class="graph-container left">
-<h3><%= @league_night.league_games[1].game.title %></h3>
-<canvas id="game1" width="800" height="400"></canvas>
-
-<script>
-
-	var data = {
-	    labels: <%= @league_night.league_games[1].scores.includes(:player).collect{|s| s.player.nickname}.to_json.html_safe %>,
-	    datasets: [
-	        {
-	            label: "My First dataset",
-	            fillColor: "rgba(189,228,168,0.5)",
-	            strokeColor: "rgba(189,228,168,0.8)",
-	            highlightFill: "rgba(123,178,168,0.75)",
-	            highlightStroke: "rgba(123,178,168,1)",
-	            data: <%= @league_night.league_games[1].scores.collect(&:score) %>
-	        }
-	    ]
-	};
-
-	var ctx = document.getElementById("game1").getContext("2d");
-	new Chart(ctx).Bar(data, {});
-
-</script>
-</div>
-
-
-<div class="graph-container left">
-<h3><%= @league_night.league_games[2].game.title %></h3>
-<canvas id="game2" width="800" height="400"></canvas>
-
-<script>
-
-	var data = {
-	    labels: <%= @league_night.league_games[2].scores.includes(:player).collect{|s| s.player.nickname}.to_json.html_safe %>,
-	    datasets: [
-	        {
-	            label: "My First dataset",
-	            fillColor: "rgba(189,228,168,0.5)",
-	            strokeColor: "rgba(189,228,168,0.8)",
-	            highlightFill: "rgba(123,178,168,0.75)",
-	            highlightStroke: "rgba(123,178,168,1)",
-	            data: <%= @league_night.league_games[2].scores.collect(&:score) %>
-	        }
-	    ]
-	};
-
-	var ctx = document.getElementById("game2").getContext("2d");
-	new Chart(ctx).Bar(data, {});
-
-</script>
-</div>
-
-<div class="graph-container left">
-<h3><%= @league_night.league_games[3].game.title %></h3>
-<canvas id="game3" width="800" height="400"></canvas>
-
-<script>
-
-	var data = {
-	    labels: <%= @league_night.league_games[3].scores.includes(:player).collect{|s| s.player.nickname}.to_json.html_safe %>,
-	    datasets: [
-	        {
-	            label: "My First dataset",
-	            fillColor: "rgba(189,228,168,0.5)",
-	            strokeColor: "rgba(189,228,168,0.8)",
-	            highlightFill: "rgba(123,178,168,0.75)",
-	            highlightStroke: "rgba(123,178,168,1)",
-	            data: <%= @league_night.league_games[3].scores.collect(&:score) %>
-	        }
-	    ]
-	};
-
-	var ctx = document.getElementById("game3").getContext("2d");
-	new Chart(ctx).Bar(data, {});
-
-</script>
-</div>
-
-<div class="graph-container left">
-<h3><%= @league_night.league_games[4].game.title %></h3>
-<canvas id="game4" width="800" height="400"></canvas>
-
-<script>
-
-	var data = {
-	    labels: <%= @league_night.league_games[4].scores.includes(:player).collect{|s| s.player.nickname}.to_json.html_safe %>,
-	    datasets: [
-	        {
-	            label: "My First dataset",
-	            fillColor: "rgba(189,228,168,0.5)",
-	            strokeColor: "rgba(189,228,168,0.8)",
-	            highlightFill: "rgba(123,178,168,0.75)",
-	            highlightStroke: "rgba(123,178,168,1)",
-	            data: <%= @league_night.league_games[4].scores.collect(&:score) %>
-	        }
-	    ]
-	};
-
-	var ctx = document.getElementById("game4").getContext("2d");
-	new Chart(ctx).Bar(data, {showBarLabels:false});
-
-</script>
-</div>
+<% end %>
 
 <br/><br/>
 <% if @admin %>


### PR DESCRIPTION
Perhaps not really necessary, but this DRYs up the chart section of the league_night show page.

No real visible changes, just allows for variable number of games and easier editing of the template in the future.